### PR TITLE
Comment form fix

### DIFF
--- a/ixwp-comments-social-login.php
+++ b/ixwp-comments-social-login.php
@@ -9,7 +9,7 @@ Version: 1.12
 License: GPLv2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
-define('IXWP_SOCIAL_COMMENTS_VERSION', '1.12');
+define('IXWP_SOCIAL_COMMENTS_VERSION', '1.15');
 define('IXWP_SOCIAL_COMMENTS_NAME', 'ixwp_social_comments');
 define('IXWP_SOCIAL_COMMENTS_SETTINGS_NAME', 'ixwp_social_comments');
 define('IXWP_SOCIAL_COMMENTS_PATH', plugin_dir_path(__FILE__));

--- a/ixwp-comments-social-login.php
+++ b/ixwp-comments-social-login.php
@@ -9,7 +9,7 @@ Version: 1.12
 License: GPLv2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
-define('IXWP_SOCIAL_COMMENTS_VERSION', '1.15');
+define('IXWP_SOCIAL_COMMENTS_VERSION', '1.16');
 define('IXWP_SOCIAL_COMMENTS_NAME', 'ixwp_social_comments');
 define('IXWP_SOCIAL_COMMENTS_SETTINGS_NAME', 'ixwp_social_comments');
 define('IXWP_SOCIAL_COMMENTS_PATH', plugin_dir_path(__FILE__));

--- a/js/ixwp-comments-social-login.js
+++ b/js/ixwp-comments-social-login.js
@@ -15,9 +15,7 @@
  http://www.ixtendo.com
  */
 function ixwpscLoadCommentForm($, accessTokenRequestUrl) {
-    var container = $('#ixwp-social-comment-wrapper');
-    container.find('.ixwp-social-comment-buttons').hide();
-    container.find('.ixwp-social-comment-wait').show();
+    var container = $('#respond');
     $.get(accessTokenRequestUrl, function (data) {
         container.replaceWith($(data));
     });
@@ -26,7 +24,7 @@ function ixwpscLoadCommentForm($, accessTokenRequestUrl) {
 function ixwpscGooglePlusSigninCallback(authResult) {
     if (authResult.access_token) {
         var $ = jQuery;
-        var gplusButton = $('#ixwp-sc-googleplus-button');
+        var gplusButton = $('#postmatic-sc-googleplus-button');
         var accessTokenRequestUrl = gplusButton.data('accessTokenRequestUrl');
         var postId = gplusButton.data('postId');
         accessTokenRequestUrl = accessTokenRequestUrl + '&access_token=' + authResult.access_token + '&post_id=' + postId;
@@ -36,9 +34,9 @@ function ixwpscGooglePlusSigninCallback(authResult) {
 
 jQuery(document).ready(function ($) {
 
-    $('.ixwp-sc-toggle').toggles();
+    $('.postmatic-sc-toggle').toggles();
 
-    $('.ixwp-sc-button').on('click', function (evt) {
+    $('.postmatic-sc-button').on('click', function (evt) {
         var scId = $(this).data('scId');
         if(scId) {
             var postId = $(this).data('postId');
@@ -57,8 +55,9 @@ jQuery(document).ready(function ($) {
                             popup.close();
 
                             // By FK for FB
-                            var q = accessTokenRequestUrl.indexOf("#");
-                            accessTokenRequestUrl = accessTokenRequestUrl.slice(0,q);
+                            var q = accessTokenRequestUrl.indexOf("#");                            
+                            if (q != -1)
+                                accessTokenRequestUrl = accessTokenRequestUrl.slice(0,q);
 
                             accessTokenRequestUrl = accessTokenRequestUrl + '&post_id=' + postId;
                             ixwpscLoadCommentForm($, accessTokenRequestUrl);

--- a/js/ixwp-comments-social-login.js
+++ b/js/ixwp-comments-social-login.js
@@ -15,9 +15,11 @@
  http://www.ixtendo.com
  */
 function ixwpscLoadCommentForm($, accessTokenRequestUrl) {
-    var container = $('#respond');
+    var container = $( '#respond' );
+    var comment = $( '#comment' ).val();
     $.get(accessTokenRequestUrl, function (data) {
         container.replaceWith($(data));
+        $( '#comment' ).val( comment ).focus();
     });
 }
 


### PR DESCRIPTION
Fixed duplicate comment forms after authentication. Assuming the theme has the `respond` wrapper.

With WordPress 4.4, the comment form is first, so I also save the value of the existing comment and re-insert after the updated comment_form is loaded.
